### PR TITLE
Fix shoe model refresh and reverse rotation direction

### DIFF
--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -183,6 +183,7 @@ const Hero = () => {
           {/* Render a 3D shoe for slides that enable it, otherwise fallback to image */}
           {slides[currentSlide].threeD ? (
             <ModelViewer
+              key={`mv-${currentSlide}-${slides[currentSlide].modelUrl}`}
               className="hero-3d"
               src={slides[currentSlide].modelUrl}
               alt={slides[currentSlide].title}

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -106,7 +106,7 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
         poster={poster || ''}
         ar
         auto-rotate
-        rotation-per-second="300deg"
+        rotation-per-second="100deg"
         camera-controls
         exposure="1"
         shadow-intensity="1"

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -100,17 +100,18 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
       {/* Render model-viewer when script is loaded. The element is a custom element and will be upgraded once the script loads. */}
       {/* eslint-disable-next-line jsx-a11y/iframe-has-title */}
       <model-viewer
-        style={{ width: '100%', height: '100%', background: 'transparent' }}
-        src={src}
-        alt={alt}
-        poster={poster || ''}
-        ar
-        auto-rotate
-        rotation-per-second="100deg"
-        camera-controls
-        exposure="1"
-        shadow-intensity="1"
-      />
+   	    key={src}
+   	    style={{ width: '100%', height: '100%', background: 'transparent' }}
+   	    src={src}
+   	    alt={alt}
+   	    poster={poster || ''}
+   	    ar
+   	    auto-rotate
+   	    rotation-per-second="100deg"
+   	    camera-controls
+   	    exposure="1"
+   	    shadow-intensity="1"
+   	  />
     </div>
   );
 };

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -106,7 +106,7 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
         poster={poster || ''}
         ar
         auto-rotate
-        rotation-per-second="-30deg"
+        rotation-per-second="300deg"
         camera-controls
         exposure="1"
         shadow-intensity="1"

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -106,6 +106,7 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
         poster={poster || ''}
         ar
         auto-rotate
+        rotation-per-second="-30deg"
         camera-controls
         exposure="1"
         shadow-intensity="1"

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -8,20 +8,6 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
   const [loaded, setLoaded] = useState(false);
   const [scriptError, setScriptError] = useState(false);
 
-  // ensure the custom element uses crossorigin for model fetching (always run to keep hooks stable)
-  useEffect(() => {
-    try {
-      const el = mvRef.current && mvRef.current.querySelector('model-viewer');
-      if (el) {
-        el.setAttribute('crossorigin', 'anonymous');
-        // ensure poster is set as fallback source if provided
-        if (poster) el.setAttribute('poster', poster);
-      }
-    } catch (e) {
-      // ignore
-    }
-  }, [poster]);
-
   useEffect(() => {
     let mounted = true;
     // If model-viewer already exists, mark loaded
@@ -33,13 +19,11 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
     // inject script
     const existing = document.querySelector(`script[data-src="${MODEL_VIEWER_SRC}"]`);
     if (existing) {
-      // wait for it to load
       existing.addEventListener('load', () => mounted && setLoaded(true));
       existing.addEventListener('error', () => mounted && setScriptError(true));
       return () => { mounted = false; };
     }
 
-    // inject module and legacy scripts for broader compatibility
     const moduleSrc = MODEL_VIEWER_SRC;
     const legacySrc = 'https://unpkg.com/@google/model-viewer/dist/model-viewer-legacy.js';
 
@@ -52,7 +36,6 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
 
     const legacyScript = document.createElement('script');
     legacyScript.src = legacySrc;
-    // legacy script should run in browsers that don't support modules (no type, noModule attribute)
     legacyScript.noModule = true;
     legacyScript.async = true;
     legacyScript.crossOrigin = 'anonymous';
@@ -77,6 +60,38 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
     return () => { mounted = false; };
   }, []);
 
+  // Create/replace the model-viewer element whenever src/poster/alt/loaded changes
+  useEffect(() => {
+    if (!loaded || !mvRef.current) return;
+    const container = mvRef.current;
+
+    // remove existing children to ensure a fresh element
+    while (container.firstChild) container.removeChild(container.firstChild);
+
+    const el = document.createElement('model-viewer');
+    el.style.width = '100%';
+    el.style.height = '100%';
+    el.style.background = 'transparent';
+
+    if (src) el.setAttribute('src', src);
+    if (alt) el.setAttribute('alt', alt);
+    if (poster) el.setAttribute('poster', poster);
+
+    el.setAttribute('ar', '');
+    el.setAttribute('auto-rotate', '');
+    el.setAttribute('rotation-per-second', '100deg');
+    el.setAttribute('camera-controls', '');
+    el.setAttribute('exposure', '1');
+    el.setAttribute('shadow-intensity', '1');
+    el.setAttribute('crossorigin', 'anonymous');
+
+    container.appendChild(el);
+
+    return () => {
+      if (container.contains(el)) container.removeChild(el);
+    };
+  }, [src, poster, alt, loaded]);
+
   // if script failed or not supported, show poster or empty area
   if (scriptError) {
     return (
@@ -95,25 +110,7 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
     );
   }
 
-  return (
-    <div className={`modelviewer-wrapper ${className}`} ref={mvRef}>
-      {/* Render model-viewer when script is loaded. The element is a custom element and will be upgraded once the script loads. */}
-      {/* eslint-disable-next-line jsx-a11y/iframe-has-title */}
-      <model-viewer
-   	    key={src}
-   	    style={{ width: '100%', height: '100%', background: 'transparent' }}
-   	    src={src}
-   	    alt={alt}
-   	    poster={poster || ''}
-   	    ar
-   	    auto-rotate
-   	    rotation-per-second="100deg"
-   	    camera-controls
-   	    exposure="1"
-   	    shadow-intensity="1"
-   	  />
-    </div>
-  );
+  return <div className={`modelviewer-wrapper ${className}`} ref={mvRef} />;
 };
 
 export default ModelViewer;

--- a/src/components/ThreeShoe/ThreeShoe.jsx
+++ b/src/components/ThreeShoe/ThreeShoe.jsx
@@ -25,10 +25,10 @@ const ShoeMesh = ({ color = '#ff6b35', accent = '#222' }) => {
     return pts;
   }, []);
 
-  // subtle float/rotation
+  // subtle float/rotation (reversed direction)
   useFrame((state, delta) => {
     if (ref.current) {
-      ref.current.rotation.y += delta * 0.4;
+      ref.current.rotation.y -= delta * 0.4;
     }
   });
 
@@ -62,7 +62,7 @@ function Model({ modelUrl, castShadow = true, receiveShadow = true, scale = 1, c
   const ref = useRef();
 
   useFrame((state, delta) => {
-    if (ref.current) ref.current.rotation.y += delta * 0.3;
+    if (ref.current) ref.current.rotation.y -= delta * 0.3;
   });
 
   return (

--- a/src/components/ThreeShoe/ThreeShoe.jsx
+++ b/src/components/ThreeShoe/ThreeShoe.jsx
@@ -128,9 +128,9 @@ const ThreeShoeCanvas = ({ className, color = '#ff6b35', accent = '#222', modelU
             <ModelErrorBoundary fallback={<ShoeMesh color={color} accent={accent} />}>
               <Suspense fallback={<ShoeMesh color={color} accent={accent} />}>
                 {modelUrl && checked && canLoadModel ? (
-                  <Model modelUrl={modelUrl} scale={1} color={color} accent={accent} />
+                  <Model key={modelUrl} modelUrl={modelUrl} scale={1} color={color} accent={accent} />
                 ) : (
-                  <ShoeMesh color={color} accent={accent} />
+                  <ShoeMesh key="fallback" color={color} accent={accent} />
                 )}
               </Suspense>
             </ModelErrorBoundary>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two main issues:
- Shoe models not refreshing properly when slider changes occur
- Default shoe rotation direction needed to be reversed to match user expectations

## Code Changes

**ModelViewer Component:**
- Added dynamic key prop to force re-rendering when slide or model URL changes
- Refactored to recreate model-viewer DOM element on prop changes instead of relying on attribute updates
- Removed redundant useEffect for crossorigin attribute setting
- Cleaned up comments and simplified script loading logic

**ThreeShoe Component:**
- Reversed rotation direction for both ShoeMesh and Model components (changed `+= delta` to `-= delta`)
- Added key props to Model and ShoeMesh components to ensure proper re-rendering

**Hero Component:**
- Added composite key to ModelViewer to trigger refresh when currentSlide or modelUrl changes

These changes ensure the 3D shoe viewer properly refreshes when users interact with sliders and rotates in the expected direction.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fd4948a0362c457da48e20ebe08b6d57/stellar-space)

👀 [Preview Link](https://fd4948a0362c457da48e20ebe08b6d57-stellar-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fd4948a0362c457da48e20ebe08b6d57</projectId>-->
<!--<branchName>stellar-space</branchName>-->