### PR TITLE
Update 3D model rotation and hero slide timing

### DIFF
--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -187,7 +187,7 @@ const Hero = () => {
               className="hero-3d"
               src={slides[currentSlide].modelUrl}
               alt={slides[currentSlide].title}
-              rotationPerSecond={'100deg'}
+              rotationPerSecond={'800deg'}
             />
           ) : (
             <motion.img

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -61,7 +61,7 @@ const Hero = () => {
     if (autoPlay) {
       interval = setInterval(() => {
         nextSlide();
-      }, 5000);
+      }, 8000);
     }
     return () => clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -187,7 +187,7 @@ const Hero = () => {
               className="hero-3d"
               src={slides[currentSlide].modelUrl}
               alt={slides[currentSlide].title}
-              rotationPerSecond={'-20deg'}
+              rotationPerSecond={'100deg'}
             />
           ) : (
             <motion.img
@@ -195,7 +195,7 @@ const Hero = () => {
               alt={slides[currentSlide].title}
               className="hero-image"
               animate={{ y: [0, -15, 0] }}
-              transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
+              transition={{ duration: 1, repeat: Infinity, ease: 'easeInOut' }}
             />
           )}
 

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -187,6 +187,7 @@ const Hero = () => {
               className="hero-3d"
               src={slides[currentSlide].modelUrl}
               alt={slides[currentSlide].title}
+              rotationPerSecond={'-20deg'}
             />
           ) : (
             <motion.img

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -195,7 +195,7 @@ const Hero = () => {
               alt={slides[currentSlide].title}
               className="hero-image"
               animate={{ y: [0, -15, 0] }}
-              transition={{ duration: 40, repeat: Infinity, ease: 'easeInOut' }}
+              transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
             />
           )}
 

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -187,7 +187,7 @@ const Hero = () => {
               className="hero-3d"
               src={slides[currentSlide].modelUrl}
               alt={slides[currentSlide].title}
-              rotationPerSecond={'800deg'}
+              rotationPerSecond={'100deg'}
             />
           ) : (
             <motion.img
@@ -195,7 +195,7 @@ const Hero = () => {
               alt={slides[currentSlide].title}
               className="hero-image"
               animate={{ y: [0, -15, 0] }}
-              transition={{ duration: 1, repeat: Infinity, ease: 'easeInOut' }}
+              transition={{ duration: 40, repeat: Infinity, ease: 'easeInOut' }}
             />
           )}
 

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -3,7 +3,7 @@ import './ModelViewer.css';
 
 const MODEL_VIEWER_SRC = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
 
-const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) => {
+const ModelViewer = ({ src, alt = '3D model', className = '', poster = null, autoRotate = true, rotationPerSecond = '30deg' }) => {
   const mvRef = useRef(null);
   const [loaded, setLoaded] = useState(false);
   const [scriptError, setScriptError] = useState(false);
@@ -78,8 +78,8 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null }) =
     if (poster) el.setAttribute('poster', poster);
 
     el.setAttribute('ar', '');
-    el.setAttribute('auto-rotate', '');
-    el.setAttribute('rotation-per-second', '100deg');
+    if (autoRotate) el.setAttribute('auto-rotate', '');
+    if (rotationPerSecond) el.setAttribute('rotation-per-second', rotationPerSecond);
     el.setAttribute('camera-controls', '');
     el.setAttribute('exposure', '1');
     el.setAttribute('shadow-intensity', '1');


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses changes to the 3D model display in the hero section, specifically updating the rotation behavior and timing to improve the visual presentation.

## Code changes
- **Hero component**: Increased slide autoplay interval from 5 seconds to 8 seconds for better viewing time
- **Hero component**: Added explicit `rotationPerSecond` prop set to '100deg' for the 3D model viewer
- **ModelViewer component**: Made auto-rotation configurable with new `autoRotate` and `rotationPerSecond` props
- **ModelViewer component**: Updated default rotation speed from hardcoded '100deg' to configurable '30deg' default
- **ModelViewer component**: Added conditional rendering of rotation attributes based on prop valuesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fd4948a0362c457da48e20ebe08b6d57/orbit-studio)

👀 [Preview Link](https://fd4948a0362c457da48e20ebe08b6d57-orbit-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fd4948a0362c457da48e20ebe08b6d57</projectId>-->
<!--<branchName>orbit-studio</branchName>-->