### PR TITLE
Add 3D shoe models and improve mobile visibility

### DIFF
--- a/src/components/Hero/Hero.css
+++ b/src/components/Hero/Hero.css
@@ -293,8 +293,13 @@
 
 @media (max-width: 576px) {
   .hero {
+    min-height: 0;
     height: auto;
-    padding: 5rem 0;
+    padding: 4rem 0;
+  }
+
+  .hero-container {
+    height: auto;
   }
 
   .hero-title {
@@ -314,14 +319,25 @@
     font-size: 0.9rem;
   }
 
-  /* Smaller 3D canvas on phones to preserve viewport space */
+  /* Ensure the model is visible but compact on phones */
+  .hero-image-container {
+    height: 40vh;
+    padding: 0 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .hero-3d {
     max-height: 40vh;
     max-width: 100%;
     transform: rotate(0deg);
+    z-index: 4;
   }
 
   .hero-3d canvas {
     transform: rotate(0deg) !important;
+    width: auto !important;
+    height: 100% !important;
   }
 }

--- a/src/components/Hero/Hero.css
+++ b/src/components/Hero/Hero.css
@@ -297,4 +297,15 @@
     padding: 0.75rem 1.5rem;
     font-size: 0.9rem;
   }
+
+  /* Smaller 3D canvas on phones to preserve viewport space */
+  .hero-3d {
+    max-height: 40vh;
+    max-width: 100%;
+    transform: rotate(0deg);
+  }
+
+  .hero-3d canvas {
+    transform: rotate(0deg) !important;
+  }
 }

--- a/src/components/Hero/Hero.css
+++ b/src/components/Hero/Hero.css
@@ -257,6 +257,22 @@
   .hero-image {
     max-height: 50vh;
   }
+
+  /* Ensure 3D canvas scales nicely on tablet and mobile */
+  .hero-3d {
+    max-height: 50vh;
+    max-width: 100%;
+    transform: rotate(0deg);
+  }
+
+  .hero-3d canvas {
+    transform: rotate(0deg) !important;
+    border-radius: 12px;
+  }
+
+  .hero-image-container {
+    padding: 0 1rem;
+  }
 }
 
 @media (max-width: 576px) {

--- a/src/components/Hero/Hero.css
+++ b/src/components/Hero/Hero.css
@@ -232,17 +232,27 @@
 
 /* Responsive */
 @media (max-width: 992px) {
+  /* Allow hero to shrink on smaller screens so 3D canvas is visible */
+  .hero {
+    min-height: 0;
+    height: auto;
+    padding-bottom: 2rem;
+  }
+
   .hero-container {
     flex-direction: column;
     justify-content: center;
     text-align: center;
     padding-top: 5rem;
+    height: auto;
   }
 
   .hero-content {
     padding-right: 0;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
     max-width: 100%;
+    order: 1;
+    z-index: 5;
   }
 
   .hero-title {
@@ -255,14 +265,16 @@
   }
 
   .hero-image {
-    max-height: 50vh;
+    max-height: 40vh;
   }
 
   /* Ensure 3D canvas scales nicely on tablet and mobile */
   .hero-3d {
-    max-height: 50vh;
+    max-height: 45vh;
     max-width: 100%;
     transform: rotate(0deg);
+    order: 2;
+    z-index: 4;
   }
 
   .hero-3d canvas {
@@ -272,6 +284,10 @@
 
   .hero-image-container {
     padding: 0 1rem;
+    height: 45vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }
 

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -186,6 +186,7 @@ const Hero = () => {
               key={`mv-${currentSlide}-${slides[currentSlide].modelUrl}`}
               className="hero-3d"
               src={slides[currentSlide].modelUrl}
+              poster={slides[currentSlide].image}
               alt={slides[currentSlide].title}
               rotationPerSecond={'100deg'}
             />

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -50,7 +50,7 @@ const Hero = () => {
       threeD: true,
       color: '#0d6efd',
       accent: '#0b2545',
-      modelUrl: 'https://cdn.builder.io/o/assets%2Fad449939a7dd4bddae2e1ca210d150b7%2F46e23d39ee9a412ba423c502db72469a?alt=media&token=f333f103-13c5-421d-bde6-75a53f118aea&apiKey=ad449939a7dd4bddae2e1ca210d150b7',
+      modelUrl: 'https://cdn.builder.io/o/assets%2F6a0d17144ec44352910fe93bc426f48e%2F315fc71e2cbd4700837d80ef82e5f778?alt=media&token=d0cad0e5-f48b-4fd3-96bc-ca71114c2b7d&apiKey=6a0d17144ec44352910fe93bc426f48e',
       lighting: { ambient: 0.6, key: 0.9, keyPos: [5, 9, 5], fill: 0.3 }
     }
   ];

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -36,7 +36,7 @@ const Hero = () => {
       threeD: true,
       color: '#ffffff',
       accent: '#e74c3c',
-      modelUrl: 'https://cdn.builder.io/o/assets%2Fad449939a7dd4bddae2e1ca210d150b7%2F46e23d39ee9a412ba423c502db72469a?alt=media&token=f333f103-13c5-421d-bde6-75a53f118aea&apiKey=ad449939a7dd4bddae2e1ca210d150b7',
+      modelUrl: 'https://cdn.builder.io/o/assets%2F6a0d17144ec44352910fe93bc426f48e%2Fdce3d7b51e7345a9a4e2cd678522cc44?alt=media&token=b3c718c7-e14f-4882-bcca-13bb55672655&apiKey=6a0d17144ec44352910fe93bc426f48e',
       lighting: { ambient: 0.45, key: 1.1, keyPos: [6, 12, 6], fill: 0.35 }
     },
     {

--- a/src/components/ModelViewer/ModelViewer.css
+++ b/src/components/ModelViewer/ModelViewer.css
@@ -1,6 +1,7 @@
 .modelviewer-wrapper {
   width: 100%;
   height: 100%;
+  max-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ModelViewer/ModelViewer.css
+++ b/src/components/ModelViewer/ModelViewer.css
@@ -7,6 +7,15 @@
   justify-content: center;
 }
 
+@media (max-width: 992px) {
+  .modelviewer-wrapper { max-height: 45vh; }
+}
+
+@media (max-width: 576px) {
+  .modelviewer-wrapper { max-height: 40vh; }
+  .modelviewer-wrapper img { max-height: 40vh; }
+}
+
 .modelviewer-wrapper model-viewer {
   width: 100%;
   height: 100%;

--- a/src/components/ModelViewer/ModelViewer.jsx
+++ b/src/components/ModelViewer/ModelViewer.jsx
@@ -71,23 +71,40 @@ const ModelViewer = ({ src, alt = '3D model', className = '', poster = null, aut
     const el = document.createElement('model-viewer');
     el.style.width = '100%';
     el.style.height = '100%';
+    el.style.minHeight = '180px';
     el.style.background = 'transparent';
 
     if (src) el.setAttribute('src', src);
     if (alt) el.setAttribute('alt', alt);
     if (poster) el.setAttribute('poster', poster);
 
+    // Improve mobile visibility and reduce interaction overlays
     el.setAttribute('ar', '');
     if (autoRotate) el.setAttribute('auto-rotate', '');
     if (rotationPerSecond) el.setAttribute('rotation-per-second', rotationPerSecond);
     el.setAttribute('camera-controls', '');
+    el.setAttribute('interaction-prompt', 'none');
+    el.setAttribute('reveal', 'auto');
     el.setAttribute('exposure', '1');
     el.setAttribute('shadow-intensity', '1');
     el.setAttribute('crossorigin', 'anonymous');
 
+    // Listen for model load to ensure it becomes visible; if it fails, fall back to poster
+    const onModelLoad = () => {
+      // nothing for now, but could toggle a state if needed
+    };
+    const onModelError = () => {
+      setScriptError(true);
+    };
+
+    el.addEventListener('load', onModelLoad);
+    el.addEventListener('error', onModelError);
+
     container.appendChild(el);
 
     return () => {
+      el.removeEventListener('load', onModelLoad);
+      el.removeEventListener('error', onModelError);
       if (container.contains(el)) container.removeChild(el);
     };
   }, [src, poster, alt, loaded]);


### PR DESCRIPTION
## Purpose
The user wanted to add 3D shoe models to the second and third slides of the hero section and ensure these models are properly visible on mobile devices. The goal was to enhance the visual experience across all screen sizes while maintaining good performance on smaller devices.

## Code changes
- **Updated model URLs**: Replaced placeholder models with actual shoe models for slides 2 and 3
- **Enhanced mobile responsiveness**: Added comprehensive CSS media queries for tablet (992px) and mobile (576px) breakpoints
- **Improved 3D canvas scaling**: Added proper height constraints and flex positioning for 3D models on smaller screens
- **Mobile fallback strategy**: Implemented poster image fallback for small screens (≤576px) to ensure content visibility when 3D models may not render properly
- **Layout optimizations**: Adjusted hero section padding, margins, and z-index values for better mobile layout
- **Added poster attribute**: Included poster images as fallbacks for the 3D model viewer componentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fd4948a0362c457da48e20ebe08b6d57/echo-oasis)

👀 [Preview Link](https://fd4948a0362c457da48e20ebe08b6d57-echo-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fd4948a0362c457da48e20ebe08b6d57</projectId>-->
<!--<branchName>echo-oasis</branchName>-->