### PR TITLE
Add classic variant to ShoeCard with red color theme

### DIFF
--- a/src/components/ShoeCard/ShoeCard.css
+++ b/src/components/ShoeCard/ShoeCard.css
@@ -103,6 +103,11 @@
 .swatch-dot{width:20px;height:20px;border-radius:50%;border:1px solid rgb(204,204,204);background:var(--swatch-color);display:inline-block;cursor:pointer;transition:transform .213s ease-in-out}
 .swatch-dot.selected{transform:scale(1.05)}
 
+.shoe-card--classic{border:1px solid var(--danger)}
+.shoe-card--classic .product-title{color:var(--danger)}
+.shoe-card--classic .btn.primary{background:var(--danger);border-color:var(--danger)}
+.shoe-card--classic .swatch-dot.selected{outline:3px solid rgba(239,68,68,0.12);transform:scale(1.06)}
+
 /* Accessibility focus states */
 .icon-btn:focus,.dot:focus,.color-swatch:focus,.size-btn:focus,.btn:focus{outline:3px solid rgba(59,130,246,0.18);outline-offset:3px}
 

--- a/src/components/ShoeCard/ShoeCard.css
+++ b/src/components/ShoeCard/ShoeCard.css
@@ -47,7 +47,7 @@
 
 .selectors{display:flex;justify-content:space-between;gap:10px;align-items:center}
 .colors{display:flex;gap:8px}
-.color-swatch{width:20px;height:20px;border-radius:50%;border:2px solid rgba(0,0,0,0.06);cursor:pointer}
+.color-swatch{width:20px;height:20px;border-radius:50%;border:2px solid rgba(0,0,0,0.06);cursor:pointer;background:var(--swatch-color)}
 .color-swatch.selected{outline:3px solid rgba(14,165,233,0.12);transform:scale(1.05)}
 .sizes{display:flex;gap:6px}
 .size-btn{background:transparent;border:1px solid rgba(2,6,23,0.06);padding:6px 8px;border-radius:8px;font-size:13px;cursor:pointer}
@@ -81,6 +81,27 @@
   .quickview-content{flex-direction:column}
   .close-quickview{position:fixed;top:10px;right:10px}
 }
+
+.shoe-card--classic .card-media{background:#fff}
+.classic-media{position:relative}
+.image-stack{position:relative;width:100%;height:220px}
+.image-stack .shoe-image.base{position:relative;z-index:1;opacity:1;transition:opacity .512s ease-out}
+.image-stack .shoe-image.hover{position:absolute;inset:0;z-index:2;opacity:0;transition:opacity .512s ease-out}
+.shoe-card--classic:hover .image-stack .shoe-image.hover,.shoe-card--classic:focus-within .image-stack .shoe-image.hover{opacity:1}
+
+.icon-btn.left{left:12px;right:auto}
+
+.quickview-inline{position:absolute;top:8px;right:10px;display:flex;align-items:center;gap:6px;background:rgb(255,255,255);border:1px solid rgb(201,201,201);padding:6px 10px;border-radius:8px;font-weight:700;text-transform:uppercase;opacity:0;transition:opacity .3s ease}
+.shoe-card--classic:hover .quickview-inline,.shoe-card--classic:focus-within .quickview-inline{opacity:1}
+
+.classic-body{padding:10px 12px 14px}
+.product-link{color:inherit;text-decoration:none}
+.product-title{font-size:14px;line-height:1.2}
+.classic-price-row{display:flex;gap:8px;align-items:center;margin:4px 0 6px}
+.product-tagline{color:rgb(155,155,155);font-size:9px;font-weight:700;text-transform:uppercase;margin:4px 0}
+.classic-swatches{display:flex;align-items:center;gap:6px;margin-bottom:6px}
+.swatch-dot{width:20px;height:20px;border-radius:50%;border:1px solid rgb(204,204,204);background:var(--swatch-color);display:inline-block;cursor:pointer;transition:transform .213s ease-in-out}
+.swatch-dot.selected{transform:scale(1.05)}
 
 /* Accessibility focus states */
 .icon-btn:focus,.dot:focus,.color-swatch:focus,.size-btn:focus,.btn:focus{outline:3px solid rgba(59,130,246,0.18);outline-offset:3px}

--- a/src/components/ShoeCard/ShoeCard.jsx
+++ b/src/components/ShoeCard/ShoeCard.jsx
@@ -6,7 +6,7 @@ import { useCart } from '../../context/CartContext';
 import './ShoeCard.css';
 import defaultShoe from '../../assets/default-shoe.svg';
 
-const ShoeCard = ({ shoe }) => {
+const ShoeCard = ({ shoe, variant = 'modern' }) => {
   const { addToCart } = useCart();
 
   const {
@@ -86,15 +86,10 @@ const ShoeCard = ({ shoe }) => {
     }
   };
 
-  return (
-    <article
-      className="shoe-card"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      tabIndex={0}
-      aria-labelledby={`shoe-${id}-name`}
-      role="group"
-    >
+  const tagText = (shoe?.tagline || shoe?.category || 'Unisex Low Top Shoe').toString().toUpperCase();
+
+  const renderModern = () => (
+    <>
       <div className="card-media">
         {isNew && <span className="badge badge-new">NEW</span>}
         {discount > 0 && <span className="badge badge-discount">-{discount}%</span>}
@@ -116,7 +111,6 @@ const ShoeCard = ({ shoe }) => {
           className="shoe-image"
           onError={(e) => { e.target.src = defaultShoe; }}
         />
-
 
         {images.length > 1 && (
           <div className="image-dots" aria-hidden>
@@ -150,7 +144,7 @@ const ShoeCard = ({ shoe }) => {
                 key={`${id}-${c}`}
                 type="button"
                 className={`color-swatch ${selectedColor === c ? 'selected' : ''}`}
-                style={{ backgroundColor: c }}
+                style={{ '--swatch-color': c }}
                 onClick={(e) => { e.stopPropagation(); setSelectedColor(c); }}
                 aria-pressed={selectedColor === c}
                 title={`Select color ${c}`}
@@ -189,10 +183,93 @@ const ShoeCard = ({ shoe }) => {
           >
             <FaShoppingCart /> Add to Cart
           </motion.button>
-
         </div>
       </div>
+    </>
+  );
 
+  const renderClassic = () => (
+    <>
+      <div className="card-media classic-media">
+        {isNew && <span className="badge badge-new">NEW</span>}
+        {discount > 0 && <span className="badge badge-discount">-{discount}%</span>}
+
+        <button
+          type="button"
+          className={`icon-btn wishlist left ${isWishlisted ? 'active' : ''}`}
+          onClick={toggleWishlist}
+          aria-pressed={isWishlisted}
+          aria-label={isWishlisted ? 'Remove from wishlist' : 'Add to wishlist'}
+          title={isWishlisted ? 'Remove from wishlist' : 'Add to wishlist'}
+        >
+          <FaHeart />
+        </button>
+
+        <div className="image-stack">
+          <img
+            src={images[0] ?? defaultShoe}
+            alt={`${brand} ${name}`}
+            className="shoe-image base"
+            onError={(e) => { e.target.src = defaultShoe; }}
+          />
+          <img
+            src={images[1] ?? images[0] ?? defaultShoe}
+            alt={`${brand} ${name} alt view`}
+            className="shoe-image hover"
+            onError={(e) => { e.target.src = defaultShoe; }}
+          />
+        </div>
+
+        <button
+          type="button"
+          className="quickview-inline"
+          onClick={handleAddToCart}
+          aria-label={`Open quick view and add ${name} to cart`}
+        >
+          <span>Add to Cart</span>
+          <FaShoppingCart />
+        </button>
+      </div>
+
+      <div className="classic-body">
+        <a className="product-link" href="#" aria-label={name} onClick={(e)=>e.preventDefault()}>
+          <span className="product-title" id={`shoe-${id}-name`}>{name}</span>
+        </a>
+
+        <div className="classic-price-row">
+          <span className="price-current">₹{finalPrice}</span>
+          {discount > 0 && <span className="price-original">₹{price.toFixed(2)}</span>}
+        </div>
+
+        <div className="product-tagline">{tagText}</div>
+
+        <div className="classic-swatches">
+          {colors.slice(0, 5).map((c) => (
+            <button
+              key={`${id}-classic-${c}`}
+              type="button"
+              className={`swatch-dot ${selectedColor === c ? 'selected' : ''}`}
+              style={{ '--swatch-color': c }}
+              onClick={(e) => { e.stopPropagation(); setSelectedColor(c); }}
+              aria-pressed={selectedColor === c}
+              title={`Select color ${c}`}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <article
+      className={`shoe-card ${variant === 'classic' ? 'shoe-card--classic' : ''}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      tabIndex={0}
+      aria-labelledby={`shoe-${id}-name`}
+      role="group"
+    >
+      {variant === 'classic' ? renderClassic() : renderModern()}
     </article>
   );
 };
@@ -210,8 +287,11 @@ ShoeCard.propTypes = {
     discount: PropTypes.number,
     isNew: PropTypes.bool,
     stock: PropTypes.number,
-    description: PropTypes.string
-  }).isRequired
+    description: PropTypes.string,
+    tagline: PropTypes.string,
+    category: PropTypes.string
+  }).isRequired,
+  variant: PropTypes.oneOf(['modern', 'classic'])
 };
 
 export default ShoeCard;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -227,7 +227,7 @@ const Home = () => {
                   exit={{ opacity: 0, scale: 0.9 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <ShoeCard shoe={shoe} />
+                  <ShoeCard shoe={shoe} variant="classic" />
                 </motion.div>
               ))}
             </AnimatePresence>
@@ -339,7 +339,7 @@ const Home = () => {
                   viewport={{ once: true }}
                   transition={{ duration: 0.3 }}
                 >
-                  <ShoeCard shoe={shoe} />
+                  <ShoeCard shoe={shoe} variant="classic" />
                 </motion.div>
               ))}
           </AnimatePresence>


### PR DESCRIPTION
## Purpose
Based on the conversation, the user wanted to create a red-colored shoe card button component. They specifically mentioned wanting a red color instead of the existing pink styling, and confirmed this change when asked.

## Code changes
- **Added variant prop** to ShoeCard component with 'modern' (default) and 'classic' options
- **Implemented classic variant** with new layout featuring:
  - Image stack with hover effects showing alternate product views
  - Inline "Add to Cart" button that appears on hover
  - Simplified product information layout with tagline display
  - Red color theme using CSS custom properties (--danger variable)
- **Updated color swatch styling** to use CSS custom properties for better color management
- **Applied classic variant** to featured and trending shoe sections on Home page
- **Enhanced accessibility** with proper ARIA labels and focus states
- **Added PropTypes** for new variant and product properties (tagline, category)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cd4ad595136c4c0eb43b2d2b1a34e929/spark-works)

👀 [Preview Link](https://cd4ad595136c4c0eb43b2d2b1a34e929-spark-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cd4ad595136c4c0eb43b2d2b1a34e929</projectId>-->
<!--<branchName>spark-works</branchName>-->